### PR TITLE
Add support for installing shared lib and link it to zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,9 @@ nx_add_library(csio ${CSIO_FORCE_SHARED_CRT} ${WITH_STATIC_LIBS}
 	${WITH_SHARED_LIBS} "CSIO_SHARED"
 	"${csio_VERSION_MAJOR}-${csio_VERSION_MINOR}-${csio_VERSION_PATCH}"
 	"${CSIO_SRC}")
+if (WITH_SHARED_LIBS)
+	target_link_libraries(csio-shared ${ZLIB_LIBRARIES})
+endif()
 list(APPEND LIBRARIES csio)
 
 ########################################################################
@@ -197,7 +200,12 @@ endif()
 # installation
 
 
-INSTALL(TARGETS csio DESTINATION lib)
+if (WITH_STATIC_LIBS)
+	INSTALL(TARGETS csio DESTINATION lib)
+endif()
+if (WITH_SHARED_LIBS)
+	INSTALL(TARGETS csio-shared DESTINATION lib)
+endif()
 if (WITH_dzip)
 	INSTALL(TARGETS dzip DESTINATION bin)
 endif()


### PR DESCRIPTION
I'm not very experienced with cmake, so I'm sorry if this is not the best solution.

This solves the following issues related to building and installing csio's shared lib:
- Calling `cmake` with `-DWITH_SHARED_LIBS=ON` causes `libcsio-shared.so` to be built, but it is not installed to the system directories when calling `make install`.
- Calling `cmake` with `-DWITH_SHARED_LIBS=ON -DWITH_STATIC_LIBS=OFF` fails because the static lib target ceases to be defined, but it is nevertheless referenced in the _installation_ section.
- The shared lib is currently not linked to `libz`. By linking it to `libz` it becomes more convenient and easy to load, specially when using `dlopen` or when creating bindings for languages possessing a FFI.
